### PR TITLE
Merge neighboring identical tags in `Owl.Data.from_ansidata/1` & increase coverage

### DIFF
--- a/lib/owl/data.ex
+++ b/lib/owl/data.ex
@@ -6,7 +6,7 @@ defmodule Owl.Data do
   alias Owl.Data.Sequence
 
   @typedoc """
-  A recursive data type that is similar to  `t:iodata/0`, but additionally supports `t:Owl.Tag.t/1`.
+  A recursive data type that is similar to `t:iodata/0`, but additionally supports `t:Owl.Tag.t/1`.
 
   Can be printed using `Owl.IO.puts/2`.
   """
@@ -360,9 +360,18 @@ defmodule Owl.Data do
     {tail, open_tags} = do_from_ansidata(tail, open_tags)
 
     case {head, tail} do
-      {[], _} -> {tail, open_tags}
-      {_, []} -> {head, open_tags}
-      _ -> {[head, tail], open_tags}
+      {[], _} ->
+        {tail, open_tags}
+
+      {_, []} ->
+        {head, open_tags}
+
+      {%Owl.Tag{data: head, sequences: s}, %Owl.Tag{data: tail, sequences: s}} ->
+        data = if is_list(tail), do: [head | tail], else: [head, tail]
+        {tag(data, s), open_tags}
+
+      _ ->
+        {[head, tail], open_tags}
     end
   end
 

--- a/test/owl/data_test.exs
+++ b/test/owl/data_test.exs
@@ -371,6 +371,12 @@ defmodule Owl.DataTest do
       assert to_from_ansidata(Owl.Data.tag("Hello", :red)) ==
                Owl.Data.tag("Hello", :red)
 
+      assert to_from_ansidata(Owl.Data.tag(["Hello", ?!], :red)) ==
+               Owl.Data.tag(["Hello", "!"], :red)
+
+      assert to_from_ansidata([Owl.Data.tag("Hello", :red), ?!]) ==
+               [Owl.Data.tag("Hello", :red), "!"]
+
       assert to_from_ansidata(["Hello ", Owl.Data.tag("world", :underline), "!"]) ==
                [["Hello ", Owl.Data.tag("world", :underline)], "!"]
 
@@ -466,6 +472,10 @@ defmodule Owl.DataTest do
                Owl.Data.tag("Hello ", :red),
                Owl.Data.tag("world", :yellow)
              ]
+    end
+
+    test "converts from charlists" do
+      assert Owl.Data.from_ansidata(["\e[31m", 'Hello']) == Owl.Data.tag('Hello', :red)
     end
 
     test "does not convert data concatenated with escape sequences" do


### PR DESCRIPTION
This PR does two things:

1. When converting ansidata to Owl data, merge neighboring identical tags when recursively constructing the data. This is especially helpful when dealing with charlists:

```elixir
# before
iex> Owl.Data.from_ansidata(IO.ANSI.format([:red, 'Hello']))
[[[[Owl.Data.tag(72, :red), Owl.Data.tag(101, :red)], Owl.Data.tag(108, :red)], Owl.Data.tag(108, :red)], Owl.Data.tag(111, :red)]

# after
iex> Owl.Data.from_ansidata(IO.ANSI.format([:red, 'Hello']))
Owl.Data.tag([[['He', 108], 108], 111], :red)
```

2. Adds missing test coverage referenced [here](https://github.com/fuelen/owl/pull/11#discussion_r1147281618).