### PR TITLE
Improvement on table rendering with integer map values.

### DIFF
--- a/lib/owl/data.ex
+++ b/lib/owl/data.ex
@@ -212,6 +212,10 @@ defmodule Owl.Data do
       ["first", "second", Owl.Data.tag(["third"], :red), Owl.Data.tag(["fourth"], :red)]
   """
   @spec lines(t()) :: [t()]
+  def lines(data) when is_integer(data) do
+    lines(to_string(data))
+  end
+
   def lines(data) do
     split(data, "\n")
   end

--- a/test/owl/table_test.exs
+++ b/test/owl/table_test.exs
@@ -21,6 +21,24 @@ defmodule Owl.TableTest do
       )
     end
 
+    test "integer values" do
+      assert_tables_equal(
+        [
+          %{"id" => 1, "name" => "Yaroslav"},
+          %{"id" => 2, "name" => "Volodymyr"}
+        ],
+        [],
+        """
+        ┌──┬─────────┐
+        │id│name     │
+        ├──┼─────────┤
+        │1 │Yaroslav │
+        │2 │Volodymyr│
+        └──┴─────────┘
+        """
+      )
+    end
+
     test "max_column_widths: pos_integer | :infinity, truncate_lines: true" do
       assert_tables_equal(
         [


### PR DESCRIPTION
Hi @fulen

I've made a little tweak to the table rendering. 
I noticed there was a bit of an oddity when a map value was an integer - it wasn't quite displaying right. 
So, I made some adjustments to ensure these values are properly converted to a string for rendering.