### PR TITLE
Add abillity to replace device in LiveScreen

### DIFF
--- a/lib/owl/live_screen.ex
+++ b/lib/owl/live_screen.ex
@@ -79,6 +79,29 @@ defmodule Owl.LiveScreen do
   end
 
   @doc """
+  Allows updating the device of the LiveScreen.
+
+  This is useful for example when using the Erlang SSH console.
+
+  ## Example
+      group_leader = Process.group_leader()
+
+      Owl.LiveScreen.set_device(group_leader)
+  """
+  @spec set_device(GenServer.server(), IO.device()) :: :ok
+  def set_device(server \\ __MODULE__, new_leader) do
+    GenServer.call(server, {:set_device, new_leader})
+  end
+
+  @doc """
+  Returns the current device used by the LiveScreen.
+  """
+  @spec get_device(GenServer.server()) :: IO.device()
+  def get_device(server \\ __MODULE__) do
+    GenServer.call(server, :get_device)
+  end
+
+  @doc """
   Redirects output from `:stdio` to `#{inspect(__MODULE__)}`.
 
   ## Example
@@ -282,6 +305,18 @@ defmodule Owl.LiveScreen do
   end
 
   @impl true
+  def handle_call({:set_device, new_device}, _, state) do
+    state = render(state)
+
+    state = init_state(state.terminal_width, state.refresh_every, new_device)
+
+    {:reply, :ok, state}
+  end
+
+  def handle_call(:get_device, _, state) do
+    {:reply, state.device, state}
+  end
+
   def handle_call(:flush, _, state) do
     state = render(state)
 

--- a/lib/owl/live_screen.ex
+++ b/lib/owl/live_screen.ex
@@ -89,8 +89,8 @@ defmodule Owl.LiveScreen do
       Owl.LiveScreen.set_device(group_leader)
   """
   @spec set_device(GenServer.server(), IO.device()) :: :ok
-  def set_device(server \\ __MODULE__, new_leader) do
-    GenServer.call(server, {:set_device, new_leader})
+  def set_device(server \\ __MODULE__, new_device) do
+    GenServer.call(server, {:set_device, new_device})
   end
 
   @doc """

--- a/test/owl/live_screen_test.exs
+++ b/test/owl/live_screen_test.exs
@@ -100,4 +100,30 @@ defmodule Owl.LiveScreenTest do
       terminal_height: 5
     )
   end
+
+  test "set_device and get_device" do
+    terminal_width = 50
+    terminal_height = 20
+
+    device1 =
+      ExUnit.Callbacks.start_supervised!(
+        {VirtualLiveScreen.Device, pid: self(), columns: terminal_width, rows: terminal_height},
+        id: :device1
+      )
+
+    device2 =
+      ExUnit.Callbacks.start_supervised!(
+        {VirtualLiveScreen.Device, pid: self(), columns: terminal_width, rows: terminal_height},
+        id: :device2
+      )
+
+    live_screen_pid =
+      ExUnit.Callbacks.start_supervised!(
+        {Owl.LiveScreen, device: device1, terminal_width: terminal_width}
+      )
+
+    assert Owl.LiveScreen.get_device(live_screen_pid) == device1
+    assert Owl.LiveScreen.set_device(live_screen_pid, device2) == :ok
+    assert Owl.LiveScreen.get_device(live_screen_pid) == device2
+  end
 end


### PR DESCRIPTION
On [Nerves](https://nerves-project.org/) based devices, we often redirect the standard console to a few places:
1) Erlang's built in [SSH](https://www.erlang.org/doc/apps/ssh/ssh.html) console
2) The [NervesHub](https://www.nerves-hub.org/) remote console

In both cases, `:stdio` does *not* refer to the correct console. This PR adds the ability to change it on a per connection basis.