### PR TITLE
Avoid deprecation warning: List.zip -> Enum.zip

### DIFF
--- a/lib/owl/palette.ex
+++ b/lib/owl/palette.ex
@@ -75,7 +75,7 @@ defmodule Owl.Palette do
     |> List.update_at(-1, fn codes ->
       Enum.concat(codes, List.duplicate("", 15))
     end)
-    |> List.zip()
+    |> Enum.zip()
     |> Enum.map(&Tuple.to_list/1)
     |> Enum.intersperse("\n")
   end


### PR DESCRIPTION
Elixir 1.18.2:

```
    warning: List.zip/1 is deprecated. Use Enum.zip/1 instead
    │
 78 │     |> List.zip()
    │             ~
    │
    └─ lib/owl/palette.ex:78:13: Owl.Palette.codes/0
```

Enum.zip/1 is safe since forever afaik https://github.com/elixir-lang/elixir/blob/v1.0/lib/elixir/lib/enum.ex

Example of it popping up when using owl in igniter:
<img width="1511" alt="Screenshot 2025-01-24 at 21 52 54" src="https://github.com/user-attachments/assets/024e53be-61ed-4c93-938d-72e1920a65cf" />
