### PR TITLE
Fix tests for Elixir 1.19.2

### DIFF
--- a/test/owl/system_test.exs
+++ b/test/owl/system_test.exs
@@ -40,7 +40,7 @@ defmodule Owl.SystemTest do
           )
         end)
 
-      assert log =~ "$ PASSWORD=******** USERNAME= sh -c \"sleep ********\"\n"
+      assert log =~ "$ PASSWORD=******** USERNAME= sh -c \"sleep ********\""
     end
 
     test "successful run with :ready_check option" do
@@ -158,15 +158,15 @@ defmodule Owl.SystemTest do
   test inspect(&Owl.System.cmd/3) do
     assert capture_log(fn ->
              Owl.System.cmd("echo", [])
-           end) =~ "$ echo\n"
+           end) =~ "$ echo"
 
     assert capture_log(fn ->
              Owl.System.cmd("echo", ["http://example.com"])
-           end) =~ "$ echo http://example.com\n"
+           end) =~ "$ echo http://example.com"
 
     assert capture_log(fn ->
              Owl.System.cmd("echo", ["http://example.com", secret: "password"])
-           end) =~ "$ echo http://example.com ********\n"
+           end) =~ "$ echo http://example.com ********"
 
     assert capture_log(fn ->
              Owl.System.cmd("echo", [
@@ -174,7 +174,7 @@ defmodule Owl.SystemTest do
                "-tAc",
                "SELECT 1;"
              ])
-           end) =~ "$ echo postgresql://postgres:********@127.0.0.1:5432 -tAc 'SELECT 1;'\n"
+           end) =~ "$ echo postgresql://postgres:********@127.0.0.1:5432 -tAc 'SELECT 1;'"
 
     assert capture_log(fn ->
              Owl.System.cmd(
@@ -187,13 +187,13 @@ defmodule Owl.SystemTest do
                ]
              )
            end) =~
-             "$ GREETING='hello world' SINGLE_WORD=single PASSWORD=******** sh -c \"echo 'hello world' --password=********\"\n"
+             "$ GREETING='hello world' SINGLE_WORD=single PASSWORD=******** sh -c \"echo 'hello world' --password=********\""
   end
 
   test inspect(&Owl.System.shell/2) do
     assert capture_log(fn ->
              Owl.System.shell("echo hello world")
-           end) =~ "$ sh -c \"echo hello world\"\n"
+           end) =~ "$ sh -c \"echo hello world\""
 
     assert capture_log(fn ->
              Owl.System.shell("echo hello world",
@@ -204,6 +204,6 @@ defmodule Owl.SystemTest do
                ]
              )
            end) =~
-             "$ GREETING='hello world' SINGLE_WORD=single PASSWORD=******** sh -c \"echo hello world\"\n"
+             "$ GREETING='hello world' SINGLE_WORD=single PASSWORD=******** sh -c \"echo hello world\""
   end
 end


### PR DESCRIPTION
Problem:
  Elixir 1.19.2's patch changed `Logger` to add reset ANSI escape codes
  before newlines.
  (See
  https://github.com/elixir-lang/elixir/blob/v1.19/CHANGELOG.md#logger-2)

Solution:
  Removing the line return from the tests' pattern seem enough as they
  are not critical to the meaning of the tests themselves.

---

Hello, I noticed some tests fail when using Elixir 1.19.2 with Erlang 28. I did some narrowing by testing various versions and found the root cause described above. Here is my proposition to fix it, although it's not a real problem since it does not affect the usage of the package.